### PR TITLE
fix: add SELinux compatibility flag for bind-mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ docker compose build && docker compose up
 If you want to skip the auth0 setup and just disable the authentication altogether, set the `PUDL_VIEWER_LOGIN_DISABLED` env var:
 
 ```bash
-$ PUDL_VIEWER_LOGIN_DISABLED=true compose up
+$ PUDL_VIEWER_LOGIN_DISABLED=true docker compose up
 ```
 
 You won't be able to log in, but you won't have to, to see the preview functionality.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,13 @@ services:
       - type: bind
         source: eel_hole
         target: /app/eel_hole
+        bind:
+          selinux: z
       - type: bind
         source: dist
         target: /app/dist
+        bind:
+          selinux: z
     ports:
       - target: 8080
         published: 8080


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

I couldn't run `docker compose up` locally because I was running into some permissions error reading `/app/eel_hole` from within the container. Turns out this was some issue with how bind-mounts are done in Fedora. Adding `selinux: z` fixes this.

# Testing

I ran `docker compose up` on my machine, which is running fedora, and it works now.

It would be good if this still worked in MacOS - @marianneke can you check on your machine?

# To-do list


- [x] Review the PR yourself and call out any questions or issues you have

