### PR TITLE
add logic to persist feature flags in app session

### DIFF
--- a/eel_hole/config.py
+++ b/eel_hole/config.py
@@ -1,0 +1,24 @@
+import os
+
+
+class BaseConfig:
+    SECRET_KEY = os.getenv("PUDL_VIEWER_SECRET_KEY")
+    TEMPLATES_AUTO_RELOAD = True
+    LOGIN_DISABLED = os.getenv("PUDL_VIEWER_LOGIN_DISABLED", "false").lower() == "true"
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    FEATURE_FLAGS = {
+        "ferc_enabled": os.getenv("FEATURE_FERC_ENABLED", "false").lower() == "true"
+    }
+
+    # Set this only if running in Cloud Run
+    if os.getenv("IS_CLOUD_RUN"):
+        PREFERRED_URL_SCHEME = "https"
+
+
+class DevConfig(BaseConfig):
+    DEBUG = True
+    SQLALCHEMY_ECHO = True
+
+
+class ProdConfig(BaseConfig):
+    DEBUG = False


### PR DESCRIPTION
# Overview

Closes #XXXX.

In the current implementation, feature flags are not persisted in a user session. This PR adds logic to do so, in particular:
- App config includes feature flag defaults for any features currently implemented and is moved out into separate module
- Default behavior mimics other config behavior in that the config value reads from environment first
- The function that checks whether a feature flag is active reads from the url first, as before (falling back to config default), but now explicitly sets the value in the session
- The flag can be unset dynamically by explicitly setting it as false in the url

# Testing

- Added new test cases to check the persistence behavior

# To-do list

```[tasklist]
- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
