### PR TITLE
feat: privacy policy display page

### DIFF
--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -197,8 +197,6 @@ def create_app():
             db.session.add(user)
             db.session.commit()
         login_user(user, remember=True)
-        if not user.accepted_privacy_policy:
-            return redirect(url_for("privacy_policy"))
         return redirect(next_url)
 
     @login_required

--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -209,6 +209,11 @@ def create_app():
         response.delete_cookie("session")
         return response
 
+    @app.get("/privacy-policy")
+    def privacy_policy():
+        """Display the privacy policy and controls to accept/reject."""
+        return render_template("privacy-policy.html")
+
     @app.get("/search")
     def search():
         """Run a search query and return results.

--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -197,6 +197,8 @@ def create_app():
             db.session.add(user)
             db.session.commit()
         login_user(user, remember=True)
+        if not user.accepted_privacy_policy:
+            return redirect(url_for("privacy_policy"))
         return redirect(next_url)
 
     @login_required

--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -221,12 +221,26 @@ def create_app():
         return render_template("privacy-policy.html")
 
     @login_required
-    @app.post("/set-privacy-settings")
-    def set_privacy_settings():
-        """Display the privacy policy and controls to accept/reject."""
-        accepted = request.form["privacy-policy"].lower() == "accept"
-        log.info("privacy-policy", accepted=accepted)
+    @app.post("/privacy-settings")
+    def privacy_settings():
+        """POST endpoint for setting privacy settings.
+
+        Will log people out if they reject the privacy policy.
+
+        Currently handles "accept_privacy_policy" and "do_individual_outreach",
+        but not "send_newsletter".
+        """
+        accepted = (
+            "accept_privacy_policy" in request.form
+            and request.form["accept_privacy_policy"] == "on"
+        )
+        outreach = (
+            "do_individual_outreach" in request.form
+            and request.form["do_individual_outreach"] == "on"
+        )
+        log.info("privacy-policy", accepted=accepted, outreach=outreach)
         current_user.accepted_privacy_policy = accepted
+        current_user.do_individual_outreach = outreach
         db.session.commit()
         if not accepted:
             return redirect(url_for("logout"))

--- a/eel_hole/templates/partials/navbar.html
+++ b/eel_hole/templates/partials/navbar.html
@@ -14,6 +14,7 @@
                 conventions</a>
             <a class="navbar-item" href="https://youtu.be/-mU7QwAZY8c">Tutorial video</a>
             <a class="navbar-item" href="https://forms.gle/ohzyKRoQutqxY3WZ6">Submit feedback</a>
+            <a class="navbar-item" href="/privacy-policy">Privacy policy</a>
         </div>
         <div class="navbar-end">
             {% if current_user.is_authenticated %}

--- a/eel_hole/templates/partials/navbar.html
+++ b/eel_hole/templates/partials/navbar.html
@@ -14,7 +14,6 @@
                 conventions</a>
             <a class="navbar-item" href="https://youtu.be/-mU7QwAZY8c">Tutorial video</a>
             <a class="navbar-item" href="https://forms.gle/ohzyKRoQutqxY3WZ6">Submit feedback</a>
-            <a class="navbar-item" href="/privacy-policy">Privacy policy</a>
         </div>
         <div class="navbar-end">
             {% if current_user.is_authenticated %}

--- a/eel_hole/templates/partials/privacy-form.html
+++ b/eel_hole/templates/partials/privacy-form.html
@@ -1,0 +1,33 @@
+<form class="block" action="/privacy-settings" method="POST">
+  <div class="field">
+    <div class="control">
+      <label class="checkbox">
+        <input
+          type="checkbox"
+          name="accept_privacy_policy"
+          {{ "checked" if current_user.accepted_privacy_policy }}
+        />
+        I accept the terms of this privacy policy.
+      </label>
+    </div>
+    <div class="control">
+      <label class="checkbox">
+        <input
+          type="checkbox"
+          name="do_individual_outreach"
+          {{ "checked" if current_user.do_individual_outreach }}
+        />
+        (optional) I would be OK with you reaching out to me as an individual based on my usage history.
+      </label>
+    </div>
+  </div>
+  <div class="field">
+    <div class="control">
+      <input
+        class="button is-primary"
+        type="submit"
+        value="Save"
+      />
+    </div>
+  </div>
+</form>

--- a/eel_hole/templates/partials/privacy-form.html
+++ b/eel_hole/templates/partials/privacy-form.html
@@ -7,7 +7,7 @@
           name="accept_privacy_policy"
           {{ "checked" if current_user.accepted_privacy_policy }}
         />
-        I accept the terms of this privacy policy.
+        <span class="has-text-danger">*</span> I accept the terms of this privacy policy.
       </label>
     </div>
     <div class="control">

--- a/eel_hole/templates/partials/privacy-form.html
+++ b/eel_hole/templates/partials/privacy-form.html
@@ -17,7 +17,7 @@
           name="do_individual_outreach"
           {{ "checked" if current_user.do_individual_outreach }}
         />
-        (optional) I would be OK with you reaching out to me as an individual based on my usage history.
+        (optional) I would be OK with you reaching out to me based on my individual usage history.
       </label>
     </div>
   </div>

--- a/eel_hole/templates/privacy-policy.html
+++ b/eel_hole/templates/privacy-policy.html
@@ -8,6 +8,38 @@
   <div class="container">
 
     <div class="block title">Privacy Policy</div>
+    {% if current_user.is_authenticated %}
+      <div class="notification">
+        <div class="content">
+          <p>
+            We track some of your activity if you are logged in,
+            so we need you to accept this privacy policy
+            in order to use the logged-in features of the site.
+          </p>
+          <p>
+            If you reject the terms of the privacy policy,
+            you will be logged out,
+            but you can keep using the site as an anonymous user.
+            You can log back in and accept the privacy policy if you change your mind.
+          </p>
+        </div>
+
+        <form class="block" action="/set-privacy-settings" method="POST">
+            <input
+              class="button is-primary"
+              type="submit"
+              name="privacy-policy"
+              value="Accept"
+            />
+            <input
+              class="button is-danger"
+              type="submit"
+              name="privacy-policy"
+              value="Reject"
+            />
+        </form>
+      </div>
+    {% endif %}
 
     <div class="content">
       <p>
@@ -113,14 +145,6 @@
       </p>
     </div>
 
-    {% if current_user.is_authenticated %}
-    <div class="block">
-      <label class="checkbox">
-        <input type="checkbox" />
-        I agree to the privacy policy
-      </label>
-    </div>
-    {% endif %}
   </div>
 </div>
 

--- a/eel_hole/templates/privacy-policy.html
+++ b/eel_hole/templates/privacy-policy.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %}
+
+{% block title %}PUDL Viewer privacy policy{% endblock %}
+
+{% block content %}
+
+<div class="section">
+  <div class="container">
+
+    <div class="block title">Privacy Policy</div>
+
+    <div class="content">
+      <p>
+        We require registration for the data viewer portion of our site so that
+        we can contact you to resolve problems with excessive or abnormal usage patterns.
+        (Mostly, it's to avoid getting hammered by bots.
+        But maybe you were planning to write a bot and give it a hammer!
+        In which case, yeah, we would want to get in touch with you about that)
+      </p>
+
+      <p>
+        We retain your email address if you have signed up for an account in the data viewer.
+      </p>
+
+      <p>
+        Any additional personal information you provide to us,
+        such as through an outreach event or user survey,
+        is voluntary,
+        and does not affect the features available to you through the data viewer.
+      </p>
+
+      <p>
+        We log information about your use of the data viewer,
+        including the user id,
+        table name,
+        and other parameters of each request.
+        We retain these logs for a period of not longer than five years.
+        We use this information for the following purposes:
+      </p>
+
+      <ul>
+        <li>to monitor the responsiveness of the data viewer</li>
+        <li>to recommend to you features relevant to your use of the service</li>
+        <li>to inform feature planning and development</li>
+        <li>to identify excessive or abnormal usage patterns which may harm our system</li>
+      </ul>
+
+      <p>
+        These logs are available to all members and member candidates at Catalyst,
+        and are expunged at or before they reach five years in age.
+      </p>
+
+      <p>
+        By default, we will only use your email address to contact you in the following scenarios:
+      </p>
+
+      <ul>
+        <li>account verification</li>
+        <li>your usage of the data viewer becomes excessive or abnormal</li>
+        <li>we discover a data breach in our systems (and you should retire your password)</li>
+        <li>updates to this privacy policy</li>
+      </ul>
+
+      <p>
+        If and only if you consent, we will also use your email address for:
+      </p>
+
+      <ul>
+        <li>voluntary user outreach events or user surveys for the general community</li>
+        <li>voluntary user outreach based on your specific usage</li>
+        <li>newsletters or other mailing list traffic specifically requested by you</li>
+        <li>retrieving or deleting your data in our systems, at your request</li>
+      </ul>
+
+      <p>
+        We store the mapping from email addresses to user ids in a location separate from server logs,
+        using security measures consistent with our internal information security practices to help us keep your information secure.
+      </p>
+
+      <p>
+        Individual usage records are only ever accessible to members and member candidates at Catalyst.
+        We will never sell or share your individual user data of any kind to third parties without your explicit consent.
+      </p>
+
+      <p>
+        We may share deidentified, aggregate data in funding proposals and publications.
+        Mostly to brag.
+        Sometimes to convince someone they should let us solve a problem in the energy data domain.
+        We will use best practices in statistical reporting to ensure data cannot be reidentified.
+      </p>
+
+      <p>
+        For a copy of your data,
+        or to request your data be deleted from our systems,
+        email <a href="mailto:hello@catalyst.coop ">hello@catalyst.coop</a> with subject line "PII Data Request".
+      </p>
+
+      <p>
+        Our sites link to external services such as AWS S3, Zenodo, GitHub, and Kaggle.
+        Catalyst retrieves traffic logs from those services,
+        but does not link them to your email or user id.
+        Your use of external services is governed by those services and not by Catalyst;
+        we cannot delete records of your use of those services.
+      </p>
+
+      <p>
+        If we need to update this privacy policy for any reason,
+        we will give you at least one week’s notice via the email we have on file.
+      </p>
+
+      <p>
+        For more information, contact <a href="mailto:hello@catalyst.coop">hello@catalyst.coop</a>. 
+      </p>
+    </div>
+
+    {% if current_user.is_authenticated %}
+    <div class="block">
+      <label class="checkbox">
+        <input type="checkbox" />
+        I agree to the privacy policy
+      </label>
+    </div>
+    {% endif %}
+  </div>
+</div>
+
+{% endblock %}

--- a/eel_hole/templates/privacy-policy.html
+++ b/eel_hole/templates/privacy-policy.html
@@ -10,21 +10,27 @@
     <div class="block title">Privacy Policy</div>
     {% if current_user.is_authenticated %}
       <div class="notification">
-        <div class="content">
-          <p>
-            We track some of your activity if you are logged in,
-            so we need you to accept this privacy policy
-            in order to use the logged-in features of the site.
-          </p>
-          <p>
-            If you reject the terms of the privacy policy,
-            you will be logged out,
-            but you can keep using the site as an anonymous user.
-            You can log back in and accept the privacy policy if you change your mind.
-          </p>
-        </div>
-
-      {% include 'partials/privacy-form.html' %}
+        <details {{ "open" if not current_user.accepted_privacy_policy }}>
+          <summary class="has-text-weight-bold">Privacy settings</summary>
+          <div class="content mt-3">
+            <p>
+              We track some of your activity if you are logged in,
+              so we need you to accept this privacy policy
+              in order to use the logged-in features of the site.
+            </p>
+            <p>
+              <span class="has-text-weight-bold">
+              If you reject the terms of the privacy policy,
+              you will be logged out,
+              </span>
+              but you can keep using the site as an anonymous user.
+              You can log back in and accept the privacy policy if you change your mind.
+            </p>
+          </div>
+          <div>
+            {% include 'partials/privacy-form.html' %}
+          </div>
+        </details>
       </div>
     {% endif %}
 
@@ -111,7 +117,7 @@
       <p>
         For a copy of your data,
         or to request your data be deleted from our systems,
-        email <a href="mailto:hello@catalyst.coop ">hello@catalyst.coop</a> with subject line "PII Data Request".
+        email <a href="mailto:hello@catalyst.coop?subject=PII Data Request">hello@catalyst.coop</a> with subject line "PII Data Request".
       </p>
 
       <p>

--- a/eel_hole/templates/privacy-policy.html
+++ b/eel_hole/templates/privacy-policy.html
@@ -24,20 +24,7 @@
           </p>
         </div>
 
-        <form class="block" action="/set-privacy-settings" method="POST">
-            <input
-              class="button is-primary"
-              type="submit"
-              name="privacy-policy"
-              value="Accept"
-            />
-            <input
-              class="button is-danger"
-              type="submit"
-              name="privacy-policy"
-              value="Reject"
-            />
-        </form>
+      {% include 'partials/privacy-form.html' %}
       </div>
     {% endif %}
 

--- a/eel_hole/templates/privacy-policy.html
+++ b/eel_hole/templates/privacy-policy.html
@@ -141,7 +141,7 @@
       </p>
 
       <p>
-        For more information, contact <a href="mailto:hello@catalyst.coop">hello@catalyst.coop</a>. 
+        For more information, contact <a href="mailto:hello@catalyst.coop">hello@catalyst.coop</a>.
       </p>
     </div>
 

--- a/eel_hole/templates/privacy-policy.html
+++ b/eel_hole/templates/privacy-policy.html
@@ -5,8 +5,7 @@
 {% block content %}
 
 <div class="section">
-  <div class="container">
-
+  <div class="container is-max-desktop">
     <div class="block title">Privacy Policy</div>
     {% if current_user.is_authenticated %}
       <div class="notification">


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #50.

Adds a privacy policy page that:
* shows the privacy policy
* allows people to accept or reject it
* logs people out if they reject it
* allows people to accept or reject direct outreach

Doesn't actively show this to anyone yet. That will be implemented when we deal with #48.

# Testing

1. Log in to local instance of the app and go to `/privacy-policy`.
2. Check the "accept" checkbox and submit.
3. Note that the checkbox state has persisted on refresh.
4. Check and uncheck the "talk to me" checkbox, submit, and note that that state persists as well.
5. (look at server logs and see that the values are being logged correctly)
6. Uncheck the "I accept the privacy policy" box, submit form, and then notice that you've been logged out unceremoniously.

