### PR TITLE
feat: launch the privacy policy

### DIFF
--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -9,7 +9,14 @@ from urllib.parse import quote
 import requests
 import structlog
 from authlib.integrations.flask_client import OAuth
-from flask import Flask, redirect, request, render_template, session, url_for
+from flask import (
+    Flask,
+    redirect,
+    request,
+    render_template,
+    session,
+    url_for,
+)
 from flask_htmx import HTMX
 from flask_login import (
     LoginManager,
@@ -97,6 +104,33 @@ def __build_search_index(app):
     return datapackage, index
 
 
+def __sort_resources_by_name(resource):
+    """Helper function to enforce resource ordering with no query.
+
+    Four recommended tables show up first, then we order by layer.
+    """
+    name = resource.name
+
+    # make these tables show up first, by returning negative numbers.
+    first_tables = [
+        "out_eia__monthly_generators",
+        "out_eia923__fuel_receipts_costs",
+        "out_ferc1__yearly_all_plants",
+        "out_eia__yearly_generators",
+    ]
+    if name in first_tables:
+        return first_tables.index(name) - len(first_tables) - 1
+
+    if name.startswith("out"):
+        return 0
+    if name.startswith("core"):
+        return 1
+    if name.startswith("_out"):
+        return 2
+    if name.startswith("_core"):
+        return 3
+
+
 def create_app():
     """Main app definition.
 
@@ -106,6 +140,7 @@ def create_app():
         * accessing the db through sql alchemy
         * logins/sessions
     2. set up the search index
+    3. add a middleware that bounces people to privacy policy if necessary
     3. define a bunch of application routes
     """
     app = Flask("eel_hole", instance_relative_config=True)
@@ -129,29 +164,34 @@ def create_app():
 
     datapackage, index = __build_search_index(app)
 
-    def sort_resources_by_name(resource):
-        name = resource.name
+    sorted_resources = sorted(datapackage.resources, key=__sort_resources_by_name)
 
-        # make these tables show up first, by returning negative numbers.
-        first_tables = [
-            "out_eia__monthly_generators",
-            "out_eia923__fuel_receipts_costs",
-            "out_ferc1__yearly_all_plants",
-            "out_eia__yearly_generators",
-        ]
-        if name in first_tables:
-            return first_tables.index(name) - len(first_tables) - 1
+    @app.before_request
+    def check_for_privacy_policy():
+        """Bounce people to privacy policy if necessary.
 
-        if name.startswith("out"):
-            return 0
-        if name.startswith("core"):
-            return 1
-        if name.startswith("_out"):
-            return 2
-        if name.startswith("_core"):
-            return 3
-
-    sorted_resources = sorted(datapackage.resources, key=sort_resources_by_name)
+        All of these conditions must be met:
+        * you are logged in
+        * you have not accepted the privacy policy
+        * you are not:
+            * looking at the privacy policy
+            * setting privacy settings
+            * logging out
+            * looking at static files
+        """
+        if not current_user.is_authenticated:
+            return None
+        if current_user.accepted_privacy_policy:
+            return None
+        if request.path in {
+            "/privacy-policy",
+            "/privacy-settings",
+            "/logout",
+        }:
+            return None
+        if request.path.startswith("/static"):
+            return None
+        return redirect(f"{url_for('privacy_policy')}")
 
     @app.get("/")
     def home():

--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -278,10 +278,9 @@ def create_app():
                 accepted the privacy policy.
             do_individual_outreach: "on" -> they consented to individual
                 outreach
+            send_newsletter: "on" -> they consented to newsletter mailings
             next_url: if present, the URL they were trying to go to before being
                 forced to the privacy policy.
-
-        NOTE 2025-09-25: we don't provide or handle the "send_newsletter" flag
         """
         accepted = (
             "accept_privacy_policy" in request.form
@@ -291,9 +290,19 @@ def create_app():
             "do_individual_outreach" in request.form
             and request.form["do_individual_outreach"] == "on"
         )
-        log.info("privacy-policy", accepted=accepted, outreach=outreach)
+        newsletter = (
+            "send_newsletter" in request.form
+            and request.form["send_newsletter"] == "on"
+        )
+        log.info(
+            "privacy-policy",
+            accepted=accepted,
+            outreach=outreach,
+            newsletter=newsletter,
+        )
         current_user.accepted_privacy_policy = accepted
         current_user.do_individual_outreach = outreach
+        current_user.send_newsletter = newsletter
         db.session.commit()
         if not accepted:
             return redirect(url_for("logout"))

--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -191,7 +191,7 @@ def create_app():
             return None
         if request.path.startswith("/static"):
             return None
-        return redirect(f"{url_for('privacy_policy')}")
+        return redirect(url_for("privacy_policy", next=request.path))
 
     @app.get("/")
     def home():
@@ -215,7 +215,6 @@ def create_app():
             redirect_uri = url_for("callback", next=next, _external=True)
         else:
             redirect_uri = url_for("callback", _external=True)
-        print(redirect_uri)
         return auth0.authorize_redirect(redirect_uri=redirect_uri)
 
     @app.route("/callback")
@@ -257,8 +256,13 @@ def create_app():
 
     @app.get("/privacy-policy")
     def privacy_policy():
-        """Display the privacy policy and controls to accept/reject."""
-        return render_template("privacy-policy.html")
+        """Display the privacy policy and controls to accept/reject.
+
+        Params:
+            next: the next URL to redirect to after acceptance.
+        """
+        next = request.args.get("next")
+        return render_template("privacy-policy.html", redirect=next)
 
     @login_required
     @app.post("/privacy-settings")
@@ -284,7 +288,8 @@ def create_app():
         db.session.commit()
         if not accepted:
             return redirect(url_for("logout"))
-        return redirect(url_for("privacy_policy"))
+        next_url = request.form.get("redirect", url_for("privacy_policy"))
+        return redirect(next_url)
 
     @app.get("/search")
     def search():

--- a/eel_hole/templates/partials/navbar.html
+++ b/eel_hole/templates/partials/navbar.html
@@ -21,7 +21,7 @@
                 Log out of {{ current_user.username }}
             </a>
             {% else %}
-            <a class="button mx-2 my-1 py-2 is-primary" href="/login">
+            <a class="button mx-2 my-1 py-2 is-primary" href="/login?next={{url_for(request.endpoint)}} ">
                 Log in or sign up
             </a>
             {% endif %}

--- a/eel_hole/templates/partials/navbar.html
+++ b/eel_hole/templates/partials/navbar.html
@@ -14,6 +14,7 @@
                 conventions</a>
             <a class="navbar-item" href="https://youtu.be/-mU7QwAZY8c">Tutorial video</a>
             <a class="navbar-item" href="https://forms.gle/ohzyKRoQutqxY3WZ6">Submit feedback</a>
+            <a class="navbar-item" href="/privacy-policy">Privacy policy</a>
         </div>
         <div class="navbar-end">
             {% if current_user.is_authenticated %}
@@ -21,7 +22,7 @@
                 Log out of {{ current_user.username }}
             </a>
             {% else %}
-            <a class="button mx-2 my-1 py-2 is-primary" href="/login?next={{url_for(request.endpoint)}} ">
+            <a class="button mx-2 my-1 py-2 is-primary" href="/login?next={{request.full_path}} ">
                 Log in or sign up
             </a>
             {% endif %}

--- a/eel_hole/templates/partials/navbar.html
+++ b/eel_hole/templates/partials/navbar.html
@@ -22,7 +22,7 @@
                 Log out of {{ current_user.username }}
             </a>
             {% else %}
-            <a class="button mx-2 my-1 py-2 is-primary" href="/login?next={{request.full_path}} ">
+            <a class="button mx-2 my-1 py-2 is-primary" href="/login?next_url={{request.full_path}} ">
                 Log in or sign up
             </a>
             {% endif %}

--- a/eel_hole/templates/partials/privacy-form.html
+++ b/eel_hole/templates/partials/privacy-form.html
@@ -22,7 +22,7 @@
     </div>
   </div>
   {% if redirect %}
-    <input type="hidden" name="redirect" value={{ redirect }} />
+    <input type="hidden" name="next_url" value={{ next_url }} />
   {% endif %}
   <div class="field">
     <div class="control">

--- a/eel_hole/templates/partials/privacy-form.html
+++ b/eel_hole/templates/partials/privacy-form.html
@@ -21,6 +21,9 @@
       </label>
     </div>
   </div>
+  {% if redirect %}
+    <input type="hidden" name="redirect" value={{ redirect }} />
+  {% endif %}
   <div class="field">
     <div class="control">
       <input

--- a/eel_hole/templates/partials/privacy-form.html
+++ b/eel_hole/templates/partials/privacy-form.html
@@ -14,14 +14,25 @@
       <label class="checkbox">
         <input
           type="checkbox"
+          name="send_newsletter"
+          {{ "checked" if current_user.send_newsletter }}
+        />
+        (optional) I agree to receive the PUDL newsletter at the email address associated with my account ({{ current_user.email }}).
+      </label>
+    </div>
+    <div class="control">
+      <label class="checkbox">
+        <input
+          type="checkbox"
           name="do_individual_outreach"
           {{ "checked" if current_user.do_individual_outreach }}
         />
-        (optional) I would be OK with you reaching out to me based on my individual usage history.
+        (optional) I agree to be contacted based on my usage history to
+        discuss potential PUDL improvements and/or my user experience.
       </label>
     </div>
   </div>
-  {% if redirect %}
+  {% if next_url %}
     <input type="hidden" name="next_url" value={{ next_url }} />
   {% endif %}
   <div class="field">

--- a/eel_hole/templates/partials/search_results.html
+++ b/eel_hole/templates/partials/search_results.html
@@ -8,7 +8,7 @@
     <button class="button is-primary preview-button" :disabled="db === null" :class="{'is-loading': loading}"
       @click="showPreview = true; tableName = '{{r.name}}'">Preview / export as CSV</button>
     {% else %}
-    <a class="button is-primary preview-button" href="/login?next={{ url_for(request.endpoint, **request.args) }}">Log
+    <a class="button is-primary preview-button" href="/login?next_url={{ url_for(request.endpoint, **request.args) }}">Log
       in or sign up to preview / export as CSV</a>
     {% endif %}
     <a class="button is-link is-light"

--- a/eel_hole/templates/privacy-policy.html
+++ b/eel_hole/templates/privacy-policy.html
@@ -6,7 +6,9 @@
 
 <div class="section">
   <div class="container is-max-desktop">
-    <div class="block title">Privacy Policy</div>
+    <div class="block title">
+      {{ "Privacy Settings" if current_user.authenticated else "Privacy Policy"}}
+    </div>
     {% if current_user.is_authenticated %}
       <div class="notification">
         <details {{ "open" if not current_user.accepted_privacy_policy }}>
@@ -14,7 +16,7 @@
           <div class="content mt-3">
             <p>
               We track some of your activity if you are logged in,
-              so we need you to accept this privacy policy
+              so we need you to accept the privacy policy below
               in order to use the logged-in features of the site.
             </p>
             <p>
@@ -31,6 +33,8 @@
           </div>
         </details>
       </div>
+
+      <div class = "block subtitle">Privacy Policy</div>
     {% endif %}
 
     <div class="content">


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #47 #48.

People need to see the privacy policy and agree to it, before we start collecting user-specific data.

Once #57 is merged, we'll have a privacy policy page and people will be able to agree to it, by manually going to the super secret `/privacy-policy` URL. If they reject it, they'll get logged out.

This adds:
* a middleware that forces logged-in users to go sign the privacy policy if they haven't already.
* a link in the navbar that lets people access the privacy policy whenever they want, without needing to know the secret URL.
* some logic so that, whenever we hijack someone's flow (whether via clicking the login button, or bouncing them to the privacy policy), we drop them off nicely where they were trying to go.

# Testing

How did you make sure this worked? How can a reviewer verify this?

1. Spin up local instance
2. Log in to existing account
3. If you haven't accepted the privacy policy, you should see the privacy policy page.
4. You can try to go to other pages by clicking the logo or typing in the URL bar but you should not be able to do anything except look at the privacy policy.
5. Accept the privacy policy. You should get redirected to whichever page you were on when you clicked "log in" (probably the bare `/search` page unless you were running a search too).
6. Click on the privacy policy link in the navbar.
7. Reject the policy. You'll get logged out.
8. Log back in.
9. Accept the policy again.
10. Enjoy life.
11. Log out.
12. Log in with a new account.
13. Repeat steps 3-7 with the new account.
14. Log out.
