### PR TITLE
chore: make uv download the right python version automatically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,8 @@ dependencies = [
     "requests>=2.32.3",
     "whoosh-reloaded>=2.7.5",
 ]
+
+[tool.uv]
+
+python-preference = "only-managed"
+python-downloads = "automatic"


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?

From Slack:

> is eel-hole intended to use base/system python, or should I make a new mamba environment for it?
> 
> ```
> (base) Esker:eel-hole katie$ uv pip install -e .
> Using Python 3.12.8 environment at: /Users/katie/bin/miniforge3
>   × No solution found when resolving dependencies:
>   ╰─▶ Because the current Python version (3.12.8) does not satisfy Python>=3.13 and eel-hole==0.1.0 depends on Python>=3.13, we can conclude that eel-hole==0.1.0 cannot be used.
>       And because only eel-hole==0.1.0 is available and you require eel-hole, we can conclude that your requirements are unsatisfiable.
> ```

What I changed:
* avoid system python at all costs
  * I think the [default behavior](https://docs.astral.sh/uv/concepts/python-versions/#discovery-of-python-versions) of "use a symlink to system python if system python version is appropriate" is fine since it still creates a virtual environment so we don't get dependency hell
  * but why not. disk space is cheap.
* automatically downloads the right managed version of python if it can't find an appropriate version on your system
# Testing

`uv run python` gets it to install a new version of python.
`uv python uninstall` that version of python that was just installed
`uv run python` again to see if it reinstalls
`uv python list` and `uv python list --managed-python` to investigate python version state