### PR TITLE
feat: add user aware logs

### DIFF
--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -1,9 +1,9 @@
 """Main app definition."""
 
 import json
+import logging
 import os
 from dataclasses import asdict
-from pathlib import Path
 from urllib.parse import quote
 
 import requests
@@ -42,7 +42,8 @@ structlog.configure(
     processors=[
         structlog.processors.TimeStamper(fmt="iso"),
         structlog.processors.JSONRenderer(),
-    ]
+    ],
+    wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
 )
 log = structlog.get_logger()
 

--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -1,13 +1,11 @@
 """Main app definition."""
 
 import json
-import logging
 import os
 from dataclasses import asdict
 from urllib.parse import quote
 
 import requests
-import structlog
 from authlib.integrations.flask_client import OAuth
 from flask import (
     Flask,
@@ -31,34 +29,13 @@ from frictionless import Package
 
 from eel_hole.models import db, User
 from eel_hole.duckdb_query import ag_grid_to_duckdb, Filter
+from eel_hole.logs import log
 from eel_hole.search import initialize_index, run_search
 from eel_hole.utils import clean_descriptions
 
 AUTH0_DOMAIN = os.getenv("PUDL_VIEWER_AUTH0_DOMAIN")
 CLIENT_ID = os.getenv("PUDL_VIEWER_AUTH0_CLIENT_ID")
 CLIENT_SECRET = os.getenv("PUDL_VIEWER_AUTH0_CLIENT_SECRET")
-
-
-def user_id_adder(logger, log_method, event_dict):
-    """Add user ID to log if available.
-
-    Must be added to processor list *before* JSONRenderer, otherwise event_dict
-    will be rendered to string already.
-    """
-    if current_user:
-        event_dict["user_id"] = current_user.get_id()
-    return event_dict
-
-
-structlog.configure(
-    processors=[
-        structlog.processors.TimeStamper(fmt="iso"),
-        user_id_adder,
-        structlog.processors.JSONRenderer(),
-    ],
-    wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
-)
-log = structlog.get_logger()
 
 
 def __init_auth0(app: Flask):

--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -312,7 +312,7 @@ def create_app():
         """
         template = "partials/search_results.html" if htmx else "search.html"
         query = request.args.get("q")
-        log.info("search", url=request.path, query=query)
+        log.info("search", url=request.full_path, query=query)
 
         if query:
             resources = run_search(ix=index, raw_query=query)
@@ -352,7 +352,7 @@ def create_app():
         else:
             event = "duckdb_other"
 
-        log.info(event, url=request.path, params=dict(request.args))
+        log.info(event, url=request.full_path, params=dict(request.args))
         offset = (page - 1) * per_page
         duckdb_query.statement += f" LIMIT {per_page} OFFSET {offset}"
         return asdict(duckdb_query)

--- a/eel_hole/__init__.py
+++ b/eel_hole/__init__.py
@@ -38,9 +38,22 @@ AUTH0_DOMAIN = os.getenv("PUDL_VIEWER_AUTH0_DOMAIN")
 CLIENT_ID = os.getenv("PUDL_VIEWER_AUTH0_CLIENT_ID")
 CLIENT_SECRET = os.getenv("PUDL_VIEWER_AUTH0_CLIENT_SECRET")
 
+
+def user_id_adder(logger, log_method, event_dict):
+    """Add user ID to log if available.
+
+    Must be added to processor list *before* JSONRenderer, otherwise event_dict
+    will be rendered to string already.
+    """
+    if current_user:
+        event_dict["user_id"] = current_user.get_id()
+    return event_dict
+
+
 structlog.configure(
     processors=[
         structlog.processors.TimeStamper(fmt="iso"),
+        user_id_adder,
         structlog.processors.JSONRenderer(),
     ],
     wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),

--- a/eel_hole/logs.py
+++ b/eel_hole/logs.py
@@ -9,8 +9,10 @@ from flask_login import current_user
 def user_id_adder(logger, log_method, event_dict):
     """Add user ID to log if available.
 
-    Note that there is a difference between `user_id` not existing (no user in
-    context) and `user_id: null` (anonymous user).
+    When there is no user in context (such as during app startup), `user_id`
+    will not be added to the log event.
+    When there is a user in context but the user is anonymous, `user_id` will be
+    added to the log event, but with value `null`.
 
     Must be added to processor list *before* JSONRenderer, otherwise event_dict
     will be rendered to string already.

--- a/eel_hole/logs.py
+++ b/eel_hole/logs.py
@@ -1,0 +1,29 @@
+"Centralized logging configuration."
+
+import logging
+
+import structlog
+from flask_login import current_user
+
+
+def user_id_adder(logger, log_method, event_dict):
+    """Add user ID to log if available.
+
+    Must be added to processor list *before* JSONRenderer, otherwise event_dict
+    will be rendered to string already.
+    """
+    if current_user:
+        event_dict["user_id"] = current_user.get_id()
+    return event_dict
+
+
+structlog.configure(
+    processors=[
+        structlog.processors.TimeStamper(fmt="iso"),
+        user_id_adder,
+        structlog.processors.JSONRenderer(),
+    ],
+    wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+)
+
+log = structlog.get_logger()

--- a/eel_hole/logs.py
+++ b/eel_hole/logs.py
@@ -9,6 +9,9 @@ from flask_login import current_user
 def user_id_adder(logger, log_method, event_dict):
     """Add user ID to log if available.
 
+    Note that there is a difference between `user_id` not existing (no user in
+    context) and `user_id: null` (anonymous user).
+
     Must be added to processor list *before* JSONRenderer, otherwise event_dict
     will be rendered to string already.
     """

--- a/eel_hole/search.py
+++ b/eel_hole/search.py
@@ -19,6 +19,8 @@ from whoosh.lang.porter import stem
 from whoosh.qparser import MultifieldParser
 from whoosh.query import AndMaybe, Or, Term
 
+# NOTE 2025-09-25: Piggybacks off of the logger configuration in __init__.py
+# only because of the import order
 log = structlog.get_logger()
 
 

--- a/eel_hole/search.py
+++ b/eel_hole/search.py
@@ -3,7 +3,6 @@
 import re
 
 from frictionless import Package, Resource
-import structlog
 
 # TODO 2025-01-15: think about switching this over to py-tantivy since that's better maintained
 from whoosh import index
@@ -19,9 +18,7 @@ from whoosh.lang.porter import stem
 from whoosh.qparser import MultifieldParser
 from whoosh.query import AndMaybe, Or, Term
 
-# NOTE 2025-09-25: Piggybacks off of the logger configuration in __init__.py
-# only because of the import order
-log = structlog.get_logger()
+from eel_hole.logs import log
 
 
 def custom_stemmer(word: str) -> str:


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #51.

Changes:
* add `user_id` as a default log field, if there *is* a current user
  * note that there is a difference between `user_id` not existing (no user in context) and `user_id: null` (anonymous user)
* fix the "log.debug still showing up even though we expected the loglevel to be set to info" bug while we're here
* log `full_path` instead of `path` in the `url` field, so we get the URL params too
* pull logging config out into a separate module so the continuing function of logs from `search.py` is not subject to the specifics of import order

# Testing

Go to `/search`, run some queries, click the preview button; check that `user_id` shows up in the logs (and shows up as `null` if I'm logged out).

# To-do list

- [ ] Review the PR yourself and call out any questions or issues you have

