### PR TITLE
Rename to PUDL Data Viewer

### DIFF
--- a/eel_hole/templates/base.html
+++ b/eel_hole/templates/base.html
@@ -7,7 +7,7 @@
     <script type="module" src="{{ url_for('static', filename='index.js') }}"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='index.css') }}" />
-    <title>{% block title %}PUDL Viewer {% endblock %}</title>
+    <title>{% block title %}PUDL Data Viewer{% endblock %}</title>
 </head>
 
 <body>

--- a/eel_hole/templates/privacy-policy.html
+++ b/eel_hole/templates/privacy-policy.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}PUDL Viewer privacy policy{% endblock %}
+{% block title %}PUDL Data Viewer privacy policy{% endblock %}
 
 {% block content %}
 

--- a/eel_hole/templates/search.html
+++ b/eel_hole/templates/search.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}PUDL Data Dictionary{% endblock %}
+{% block title %}PUDL Data Viewer{% endblock %}
 
 {% block content %}
 
@@ -8,7 +8,7 @@
 
 
   <div class="notification has-background-info has-text-dark my-3" x-data="{open: true}" x-show="open">
-    Welcome! The PUDL viewer is in beta right now. We filmed a short <a class="inline"
+    Welcome! The PUDL data viewer is in beta right now. We filmed a short <a class="inline"
       href="https://youtu.be/-mU7QwAZY8c">tutorial video</a>, and would love any <a class="is-inline"
       href="https://forms.gle/ohzyKRoQutqxY3WZ6">feedback</a> you have for the site!
     <button class="delete" @click="open = !open"></button>


### PR DESCRIPTION
# Overview

- Changes the title of the site to PUDL Data Viewer, to differentiate it from the PUDL Data Dictionary in our docs and reduce confusion.

Closes #70 