### PR TITLE
Restore columns display

### DIFF
--- a/eel_hole/templates/partials/search_results.html
+++ b/eel_hole/templates/partials/search_results.html
@@ -30,7 +30,7 @@
   <div class="block">
     <details>
       <summary class="title is-5">Columns</summary>
-      {% for col in columns %}
+      {% for col in r.columns %}
       <div class="mb-2">
         <div>
           <strong>{{ col.name }}</strong>


### PR DESCRIPTION
# Overview

Make it so columns show up again!

_What problem does this address?_

We accidentally [dropped an `r.` in the search results template](https://github.com/catalyst-cooperative/eel-hole/pull/39/files#diff-8079c95dc9f5138c7d626eb88f03f59ada129bdb9d2141a0e95839c599fcf184)

_What did you change in this PR?_

Added the `r.` back in!

# Testing

_How did you make sure this worked? How can a reviewer verify this?_

* Loaded locally before the change: Blank columns
* Loaded locally after the change: Filled columns

Why this works:

* The search_results.html partial renders a list of `resources`
* `resources` is set in [the `/search` route handler](https://github.com/catalyst-cooperative/eel-hole/blob/f3135471c48f4ff7a062f41b1a602036bea35ac8/eel_hole/__init__.py#L370)
* When there's no query, it gets set to `sorted_all_resources` (when there _is_ a query, you'll have to trust me it's a list of the same kind of resource object as in `sorted_all_resources`
* `sorted_all_resources` is set in [`_create_app()`](https://github.com/catalyst-cooperative/eel-hole/blob/f3135471c48f4ff7a062f41b1a602036bea35ac8/eel_hole/__init__.py#L200), which gets it from [`__build_search_index()`](https://github.com/catalyst-cooperative/eel-hole/blob/f3135471c48f4ff7a062f41b1a602036bea35ac8/eel_hole/__init__.py#L129)
* `__build_search_index()` gets it from [`utils.clean_pudl_resource()`](https://github.com/catalyst-cooperative/eel-hole/blob/d263ac9677a88f5c01a807c82092a37515ed2c5b/eel_hole/utils.py#L145), which creates instances of [`ResourceDisplay`](https://github.com/catalyst-cooperative/eel-hole/blob/d263ac9677a88f5c01a807c82092a37515ed2c5b/eel_hole/utils.py#L21)
* `ResourceDisplay` has a `columns` attribute
* Thus when we iterate over resources, we need to fetch the `.columns` attribute of resource `r`, and not just get an unattached `columns` out of the ether

# To-do list

- [x] fix the opinionated whitespace changes my editor added against my will

